### PR TITLE
✨ refactor(rag.ingestion): Use EasyOCR

### DIFF
--- a/rag_system/ingestion/document_converter.py
+++ b/rag_system/ingestion/document_converter.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple, Dict, Any
 from docling.document_converter import DocumentConverter as DoclingConverter, PdfFormatOption
-from docling.datamodel.pipeline_options import PdfPipelineOptions, OcrMacOptions
+from docling.datamodel.pipeline_options import PdfPipelineOptions, EasyOcrOptions
 from docling.datamodel.base_models import InputFormat
 import fitz  # PyMuPDF for quick text inspection
 import os
@@ -35,7 +35,7 @@ class DocumentConverter:
             # --- Converter WITH OCR (fallback) ---
             pipeline_ocr = PdfPipelineOptions()
             pipeline_ocr.do_ocr = True
-            ocr_options = OcrMacOptions(force_full_page_ocr=True)
+            ocr_options = EasyOcrOptions(force_full_page_ocr=True)
             pipeline_ocr.ocr_options = ocr_options
             format_ocr = {
                 InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_ocr)


### PR DESCRIPTION
## 📝 Description

Use EasyOCR instead of OCRmac to make OCR available on all platforms (currently only MacOS works)

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧪 Test improvements
- [ ] 🔧 Code refactoring
- [ ] 🎨 UI/UX improvements

## 🧪 Testing

### Test Environment
- [ ] Tested with Docker deployment
- [x] Tested with direct Python deployment
- [ ] Tested on macOS
- [x] Tested on Linux
- [ ] Tested on Windows

## 📋 Checklist

### Dependencies
- [x] No new dependencies added, or new dependencies are justified => easyOCR is already included with Docling
- [ ] requirements.txt updated (if applicable)
- [ ] package.json updated (if applicable)

## 📊 Performance Impact

Describe any performance implications:
- [ ] No performance impact
- [ ] Performance improved
- [x] Performance may be affected (explain below)

## 🔄 Migration Notes

If this is a breaking change, describe what users need to do:
- [x] No migration needed
- [ ] Migration steps documented below

## 📎 Additional Notes

Now when upload a document that contains image, the OCR will transform it to text. So the indexation with take longer than before.